### PR TITLE
Finished layer 1 : DB (by hiep)

### DIFF
--- a/PMSAT.DataTier/Class1.cs
+++ b/PMSAT.DataTier/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace PMSAT.DataTier
-{
-    public class Class1
-    {
-
-    }
-}

--- a/PMSAT.DataTier/Class1.cs
+++ b/PMSAT.DataTier/Class1.cs
@@ -1,0 +1,7 @@
+﻿namespace PMSAT.DataTier
+{
+    public class Class1
+    {
+
+    }
+}

--- a/PMSAT.DataTier/Models/BackLog.cs
+++ b/PMSAT.DataTier/Models/BackLog.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class BackLog
+{
+    public Guid Id { get; set; }
+
+    public Guid? ProjectId { get; set; }
+
+    public string? Description { get; set; }
+
+    public virtual Project? Project { get; set; }
+
+    public virtual ICollection<Task> Tasks { get; set; } = new List<Task>();
+}

--- a/PMSAT.DataTier/Models/Commit.cs
+++ b/PMSAT.DataTier/Models/Commit.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class Commit
+{
+    public Guid Id { get; set; }
+
+    public Guid? RepositoryId { get; set; }
+
+    public string? Message { get; set; }
+
+    public DateTime? CreatedAt { get; set; }
+
+    public virtual Repository? Repository { get; set; }
+}

--- a/PMSAT.DataTier/Models/Feedback.cs
+++ b/PMSAT.DataTier/Models/Feedback.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class Feedback
+{
+    public Guid Id { get; set; }
+
+    public Guid? UserId { get; set; }
+
+    public string? Type { get; set; }
+
+    public string? Content { get; set; }
+
+    public virtual User? User { get; set; }
+}

--- a/PMSAT.DataTier/Models/IntegrationConfig.cs
+++ b/PMSAT.DataTier/Models/IntegrationConfig.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class IntegrationConfig
+{
+    public Guid Id { get; set; }
+
+    public Guid? UserId { get; set; }
+
+    public string? ToolName { get; set; }
+
+    public string? Settings { get; set; }
+
+    public string? ApiKey { get; set; }
+
+    public string? Url { get; set; }
+
+    public virtual User? User { get; set; }
+}

--- a/PMSAT.DataTier/Models/PmsatContext.cs
+++ b/PMSAT.DataTier/Models/PmsatContext.cs
@@ -1,0 +1,325 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class PmsatContext : DbContext
+{
+    public PmsatContext()
+    {
+    }
+
+    public PmsatContext(DbContextOptions<PmsatContext> options)
+        : base(options)
+    {
+    }
+
+    public virtual DbSet<BackLog> BackLogs { get; set; }
+
+    public virtual DbSet<Commit> Commits { get; set; }
+
+    public virtual DbSet<Feedback> Feedbacks { get; set; }
+
+    public virtual DbSet<IntegrationConfig> IntegrationConfigs { get; set; }
+
+    public virtual DbSet<Project> Projects { get; set; }
+
+    public virtual DbSet<ProjectAnalysisResult> ProjectAnalysisResults { get; set; }
+
+    public virtual DbSet<ProjectMember> ProjectMembers { get; set; }
+
+    public virtual DbSet<ProjectRole> ProjectRoles { get; set; }
+
+    public virtual DbSet<PullRequest> PullRequests { get; set; }
+
+    public virtual DbSet<Repository> Repositories { get; set; }
+
+    public virtual DbSet<RoleInProject> RoleInProjects { get; set; }
+
+    public virtual DbSet<Sprint> Sprints { get; set; }
+
+    public virtual DbSet<Task> Tasks { get; set; }
+
+    public virtual DbSet<TaskSprint> TaskSprints { get; set; }
+
+    public virtual DbSet<User> Users { get; set; }
+
+    public virtual DbSet<WorkFlow> WorkFlows { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see https://go.microsoft.com/fwlink/?LinkId=723263.
+        => optionsBuilder.UseSqlServer("Server=14.225.204.144,6789;Database=PMSAT;Uid=pmsat;Pwd=12345;TrustServerCertificate=True");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<BackLog>(entity =>
+        {
+            entity.ToTable("BackLog");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Description).HasMaxLength(250);
+
+            entity.HasOne(d => d.Project).WithMany(p => p.BackLogs)
+                .HasForeignKey(d => d.ProjectId)
+                .HasConstraintName("FK_BackLog_Project");
+        });
+
+        modelBuilder.Entity<Commit>(entity =>
+        {
+            entity.ToTable("Commit");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.CreatedAt).HasColumnType("datetime");
+            entity.Property(e => e.Message).HasMaxLength(250);
+
+            entity.HasOne(d => d.Repository).WithMany(p => p.Commits)
+                .HasForeignKey(d => d.RepositoryId)
+                .HasConstraintName("FK_Commit_Repository");
+        });
+
+        modelBuilder.Entity<Feedback>(entity =>
+        {
+            entity.ToTable("Feedback");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Content).HasMaxLength(250);
+            entity.Property(e => e.Type)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+
+            entity.HasOne(d => d.User).WithMany(p => p.Feedbacks)
+                .HasForeignKey(d => d.UserId)
+                .HasConstraintName("FK_Feedback_User");
+        });
+
+        modelBuilder.Entity<IntegrationConfig>(entity =>
+        {
+            entity.ToTable("IntegrationConfig");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.ApiKey).HasMaxLength(50);
+            entity.Property(e => e.Settings).HasMaxLength(50);
+            entity.Property(e => e.ToolName).HasMaxLength(50);
+            entity.Property(e => e.Url).HasMaxLength(50);
+
+            entity.HasOne(d => d.User).WithMany(p => p.IntegrationConfigs)
+                .HasForeignKey(d => d.UserId)
+                .HasConstraintName("FK_IntegrationConfig_User");
+        });
+
+        modelBuilder.Entity<Project>(entity =>
+        {
+            entity.ToTable("Project");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.EndDate).HasColumnType("datetime");
+            entity.Property(e => e.StartDate).HasColumnType("datetime");
+            entity.Property(e => e.Status)
+                .HasMaxLength(20)
+                .IsUnicode(false);
+        });
+
+        modelBuilder.Entity<ProjectAnalysisResult>(entity =>
+        {
+            entity.ToTable("ProjectAnalysisResult");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Complexity).HasMaxLength(50);
+            entity.Property(e => e.Converage).HasMaxLength(50);
+            entity.Property(e => e.QualityMetrics).HasMaxLength(50);
+            entity.Property(e => e.RequirementError).HasMaxLength(50);
+            entity.Property(e => e.SecurityError).HasMaxLength(50);
+            entity.Property(e => e.SyntaxError).HasMaxLength(50);
+
+            entity.HasOne(d => d.Project).WithMany(p => p.ProjectAnalysisResults)
+                .HasForeignKey(d => d.ProjectId)
+                .HasConstraintName("FK_ProjectAnalysisResult_Project");
+        });
+
+        modelBuilder.Entity<ProjectMember>(entity =>
+        {
+            entity.ToTable("ProjectMember");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.EndDate).HasColumnType("datetime");
+            entity.Property(e => e.StartDate).HasColumnType("datetime");
+            entity.Property(e => e.UpdateAt).HasColumnType("datetime");
+
+            entity.HasOne(d => d.Project).WithMany(p => p.ProjectMembers)
+                .HasForeignKey(d => d.ProjectId)
+                .HasConstraintName("FK_ProjectMember_Project");
+
+            entity.HasOne(d => d.User).WithMany(p => p.ProjectMembers)
+                .HasForeignKey(d => d.UserId)
+                .HasConstraintName("FK_ProjectMember_User");
+        });
+
+        modelBuilder.Entity<ProjectRole>(entity =>
+        {
+            entity.ToTable("ProjectRole");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Description).HasMaxLength(250);
+            entity.Property(e => e.RoleName).HasMaxLength(50);
+        });
+
+        modelBuilder.Entity<PullRequest>(entity =>
+        {
+            entity
+                .HasNoKey()
+                .ToTable("PullRequest");
+
+            entity.Property(e => e.Body).HasMaxLength(50);
+            entity.Property(e => e.CreatedAt).HasColumnType("datetime");
+            entity.Property(e => e.MergedAt).HasColumnType("datetime");
+            entity.Property(e => e.Number)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.Status)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.Title).HasMaxLength(50);
+            entity.Property(e => e.Url).HasMaxLength(50);
+
+            entity.HasOne(d => d.Repository).WithMany()
+                .HasForeignKey(d => d.RepositoryId)
+                .HasConstraintName("FK_PullRequest_Repository");
+        });
+
+        modelBuilder.Entity<Repository>(entity =>
+        {
+            entity.ToTable("Repository");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Name).HasMaxLength(250);
+            entity.Property(e => e.Owner)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.Url).HasMaxLength(50);
+
+            entity.HasOne(d => d.ProjectMember).WithMany(p => p.Repositories)
+                .HasForeignKey(d => d.ProjectMemberId)
+                .HasConstraintName("FK_Repository_ProjectMember");
+        });
+
+        modelBuilder.Entity<RoleInProject>(entity =>
+        {
+            entity.ToTable("RoleInProject");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+
+            entity.HasOne(d => d.ProjectMember).WithMany(p => p.RoleInProjects)
+                .HasForeignKey(d => d.ProjectMemberId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_RoleInProject_ProjectMember");
+
+            entity.HasOne(d => d.ProjectRole).WithMany(p => p.RoleInProjects)
+                .HasForeignKey(d => d.ProjectRoleId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_RoleInProject_ProjectRole");
+        });
+
+        modelBuilder.Entity<Sprint>(entity =>
+        {
+            entity.ToTable("Sprint");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.EndDate).HasColumnType("datetime");
+            entity.Property(e => e.Name).HasMaxLength(50);
+            entity.Property(e => e.StartDate).HasColumnType("datetime");
+            entity.Property(e => e.Status)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+
+            entity.HasOne(d => d.Project).WithMany(p => p.Sprints)
+                .HasForeignKey(d => d.ProjectId)
+                .HasConstraintName("FK_Sprint_Project");
+        });
+
+        modelBuilder.Entity<Task>(entity =>
+        {
+            entity.ToTable("Task");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Description).HasMaxLength(250);
+            entity.Property(e => e.EndDate).HasColumnType("datetime");
+            entity.Property(e => e.StartDate).HasColumnType("datetime");
+            entity.Property(e => e.Type)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+
+            entity.HasOne(d => d.Backlog).WithMany(p => p.Tasks)
+                .HasForeignKey(d => d.BacklogId)
+                .HasConstraintName("FK_Task_BackLog");
+
+            entity.HasOne(d => d.ProjectMember).WithMany(p => p.Tasks)
+                .HasForeignKey(d => d.ProjectMemberId)
+                .HasConstraintName("FK_Task_ProjectMember");
+        });
+
+        modelBuilder.Entity<TaskSprint>(entity =>
+        {
+            entity.ToTable("TaskSprint");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.EndDate).HasColumnType("datetime");
+            entity.Property(e => e.StartDate).HasColumnType("datetime");
+
+            entity.HasOne(d => d.Sprint).WithMany(p => p.TaskSprints)
+                .HasForeignKey(d => d.SprintId)
+                .HasConstraintName("FK_TaskSprint_Sprint");
+
+            entity.HasOne(d => d.Task).WithMany(p => p.TaskSprints)
+                .HasForeignKey(d => d.TaskId)
+                .HasConstraintName("FK_TaskSprint_Task");
+        });
+
+        modelBuilder.Entity<User>(entity =>
+        {
+            entity.ToTable("User");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Email)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.Password)
+                .HasMaxLength(250)
+                .IsUnicode(false);
+            entity.Property(e => e.Role)
+                .HasMaxLength(20)
+                .IsUnicode(false);
+            entity.Property(e => e.Status)
+                .HasMaxLength(20)
+                .IsUnicode(false);
+            entity.Property(e => e.Username)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+        });
+
+        modelBuilder.Entity<WorkFlow>(entity =>
+        {
+            entity.ToTable("WorkFlow");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.FromStatus)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.Status)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.ToStatus)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.UpdatedAt).HasColumnType("datetime");
+
+            entity.HasOne(d => d.Task).WithMany(p => p.WorkFlows)
+                .HasForeignKey(d => d.TaskId)
+                .HasConstraintName("FK_WorkFlow_Task");
+        });
+
+        OnModelCreatingPartial(modelBuilder);
+    }
+
+    partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+}

--- a/PMSAT.DataTier/Models/Project.cs
+++ b/PMSAT.DataTier/Models/Project.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class Project
+{
+    public Guid Id { get; set; }
+
+    public Guid? Name { get; set; }
+
+    public Guid? Description { get; set; }
+
+    public DateTime? StartDate { get; set; }
+
+    public DateTime? EndDate { get; set; }
+
+    public string? Status { get; set; }
+
+    public virtual ICollection<BackLog> BackLogs { get; set; } = new List<BackLog>();
+
+    public virtual ICollection<ProjectAnalysisResult> ProjectAnalysisResults { get; set; } = new List<ProjectAnalysisResult>();
+
+    public virtual ICollection<ProjectMember> ProjectMembers { get; set; } = new List<ProjectMember>();
+
+    public virtual ICollection<Sprint> Sprints { get; set; } = new List<Sprint>();
+}

--- a/PMSAT.DataTier/Models/ProjectAnalysisResult.cs
+++ b/PMSAT.DataTier/Models/ProjectAnalysisResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class ProjectAnalysisResult
+{
+    public Guid Id { get; set; }
+
+    public Guid? ProjectId { get; set; }
+
+    public string? Converage { get; set; }
+
+    public string? QualityMetrics { get; set; }
+
+    public string? Complexity { get; set; }
+
+    public string? SyntaxError { get; set; }
+
+    public string? SecurityError { get; set; }
+
+    public string? RequirementError { get; set; }
+
+    public virtual Project? Project { get; set; }
+}

--- a/PMSAT.DataTier/Models/ProjectMember.cs
+++ b/PMSAT.DataTier/Models/ProjectMember.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class ProjectMember
+{
+    public Guid Id { get; set; }
+
+    public Guid? UserId { get; set; }
+
+    public Guid? ProjectId { get; set; }
+
+    public DateTime? StartDate { get; set; }
+
+    public DateTime? EndDate { get; set; }
+
+    public DateTime? UpdateAt { get; set; }
+
+    public virtual Project? Project { get; set; }
+
+    public virtual ICollection<Repository> Repositories { get; set; } = new List<Repository>();
+
+    public virtual ICollection<RoleInProject> RoleInProjects { get; set; } = new List<RoleInProject>();
+
+    public virtual ICollection<Task> Tasks { get; set; } = new List<Task>();
+
+    public virtual User? User { get; set; }
+}

--- a/PMSAT.DataTier/Models/ProjectRole.cs
+++ b/PMSAT.DataTier/Models/ProjectRole.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class ProjectRole
+{
+    public Guid Id { get; set; }
+
+    public string? RoleName { get; set; }
+
+    public string? Description { get; set; }
+
+    public virtual ICollection<RoleInProject> RoleInProjects { get; set; } = new List<RoleInProject>();
+}

--- a/PMSAT.DataTier/Models/PullRequest.cs
+++ b/PMSAT.DataTier/Models/PullRequest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class PullRequest
+{
+    public Guid? Id { get; set; }
+
+    public Guid? RepositoryId { get; set; }
+
+    public string? Number { get; set; }
+
+    public string? Title { get; set; }
+
+    public string? Body { get; set; }
+
+    public DateTime? CreatedAt { get; set; }
+
+    public DateTime? MergedAt { get; set; }
+
+    public string? Status { get; set; }
+
+    public string? Url { get; set; }
+
+    public virtual Repository? Repository { get; set; }
+}

--- a/PMSAT.DataTier/Models/Repository.cs
+++ b/PMSAT.DataTier/Models/Repository.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class Repository
+{
+    public Guid Id { get; set; }
+
+    public Guid? ProjectMemberId { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? Url { get; set; }
+
+    public string? Owner { get; set; }
+
+    public virtual ICollection<Commit> Commits { get; set; } = new List<Commit>();
+
+    public virtual ProjectMember? ProjectMember { get; set; }
+}

--- a/PMSAT.DataTier/Models/RoleInProject.cs
+++ b/PMSAT.DataTier/Models/RoleInProject.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class RoleInProject
+{
+    public Guid Id { get; set; }
+
+    public Guid ProjectRoleId { get; set; }
+
+    public Guid ProjectMemberId { get; set; }
+
+    public virtual ProjectMember ProjectMember { get; set; } = null!;
+
+    public virtual ProjectRole ProjectRole { get; set; } = null!;
+}

--- a/PMSAT.DataTier/Models/Sprint.cs
+++ b/PMSAT.DataTier/Models/Sprint.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class Sprint
+{
+    public Guid Id { get; set; }
+
+    public Guid? ProjectId { get; set; }
+
+    public string? Name { get; set; }
+
+    public DateTime? StartDate { get; set; }
+
+    public DateTime? EndDate { get; set; }
+
+    public string Status { get; set; } = null!;
+
+    public virtual Project? Project { get; set; }
+
+    public virtual ICollection<TaskSprint> TaskSprints { get; set; } = new List<TaskSprint>();
+}

--- a/PMSAT.DataTier/Models/Task.cs
+++ b/PMSAT.DataTier/Models/Task.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class Task
+{
+    public Guid Id { get; set; }
+
+    public Guid? BacklogId { get; set; }
+
+    public Guid? ProjectMemberId { get; set; }
+
+    public string? Type { get; set; }
+
+    public string? Description { get; set; }
+
+    public int? Priority { get; set; }
+
+    public DateTime? StartDate { get; set; }
+
+    public DateTime? EndDate { get; set; }
+
+    public virtual BackLog? Backlog { get; set; }
+
+    public virtual ProjectMember? ProjectMember { get; set; }
+
+    public virtual ICollection<TaskSprint> TaskSprints { get; set; } = new List<TaskSprint>();
+
+    public virtual ICollection<WorkFlow> WorkFlows { get; set; } = new List<WorkFlow>();
+}

--- a/PMSAT.DataTier/Models/TaskSprint.cs
+++ b/PMSAT.DataTier/Models/TaskSprint.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class TaskSprint
+{
+    public Guid Id { get; set; }
+
+    public Guid? TaskId { get; set; }
+
+    public Guid? SprintId { get; set; }
+
+    public DateTime? StartDate { get; set; }
+
+    public DateTime? EndDate { get; set; }
+
+    public virtual Sprint? Sprint { get; set; }
+
+    public virtual Task? Task { get; set; }
+}

--- a/PMSAT.DataTier/Models/User.cs
+++ b/PMSAT.DataTier/Models/User.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class User
+{
+    public Guid Id { get; set; }
+
+    public string? Role { get; set; }
+
+    public string? Username { get; set; }
+
+    public string? Email { get; set; }
+
+    public string? Password { get; set; }
+
+    public string? Status { get; set; }
+
+    public virtual ICollection<Feedback> Feedbacks { get; set; } = new List<Feedback>();
+
+    public virtual ICollection<IntegrationConfig> IntegrationConfigs { get; set; } = new List<IntegrationConfig>();
+
+    public virtual ICollection<ProjectMember> ProjectMembers { get; set; } = new List<ProjectMember>();
+}

--- a/PMSAT.DataTier/Models/WorkFlow.cs
+++ b/PMSAT.DataTier/Models/WorkFlow.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PMSAT.DataTier.Models;
+
+public partial class WorkFlow
+{
+    public Guid Id { get; set; }
+
+    public Guid? TaskId { get; set; }
+
+    public string? Status { get; set; }
+
+    public string? FromStatus { get; set; }
+
+    public string? ToStatus { get; set; }
+
+    public DateTime? UpdatedAt { get; set; }
+
+    public virtual Task? Task { get; set; }
+}

--- a/PMSAT.DataTier/PMSAT.DataTier.csproj
+++ b/PMSAT.DataTier/PMSAT.DataTier.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/PMSAT.DataTier/PMSAT.DataTier.csproj
+++ b/PMSAT.DataTier/PMSAT.DataTier.csproj
@@ -5,5 +5,19 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+	
+  <ItemGroup>
+    <PackageReference Include="LAK.Sdk.Core" Version="7.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/PMSAT.DataTier/Paginate/IPaginate.cs
+++ b/PMSAT.DataTier/Paginate/IPaginate.cs
@@ -1,0 +1,11 @@
+﻿namespace PMSAT.DataTier.Paginate
+{
+    public interface IPaginate<TResult>
+    {
+        int Size { get; }
+        int Page { get; }
+        int Total { get; }
+        int TotalPages { get; }
+        IList<TResult> Items { get; }
+    }
+}

--- a/PMSAT.DataTier/Paginate/Paginate.cs
+++ b/PMSAT.DataTier/Paginate/Paginate.cs
@@ -1,0 +1,43 @@
+﻿namespace PMSAT.DataTier.Paginate
+{
+    public class Paginate<TResult> : IPaginate<TResult>
+    {
+        public int Size { get; set; }
+        public int Page { get; set; }
+        public int Total { get; set; }
+        public int TotalPages { get; set; }
+        public IList<TResult> Items { get; set; }
+
+        public Paginate(IEnumerable<TResult> source, int page, int size, int firstPage)
+        {
+            var enumerable = source as TResult[] ?? source.ToArray();
+
+            if (firstPage > page)
+            {
+                throw new ArgumentException($"Page ({page}) must be greater or equal than firstPage ({firstPage})");
+            }
+
+            if (source is IQueryable<TResult> queryable)
+            {
+                Page = page;
+                Size = size;
+                Total = queryable.Count();
+                Items = queryable.Skip((page - firstPage) * size).Take(size).ToList();
+                TotalPages = (int)Math.Ceiling(Total / (double)Size);
+            }
+            else
+            {
+                Page = page;
+                Size = size;
+                Total = enumerable.Length;
+                Items = enumerable.Skip((page - firstPage) * size).Take(size).ToList();
+                TotalPages = (int)Math.Ceiling(Total / (double)Size);
+            }
+        }
+
+        public Paginate()
+        {
+            Items = Array.Empty<TResult>();
+        }
+    }
+}

--- a/PMSAT.DataTier/Paginate/PaginateExtension.cs
+++ b/PMSAT.DataTier/Paginate/PaginateExtension.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace PMSAT.DataTier.Paginate
+{
+    public static class PaginateExtension
+    {
+        public static async Task<IPaginate<T>> ToPaginateAsync<T>(this IQueryable<T> queryable, int page, int size, int firstPage = 1)
+        {
+            if (firstPage > page)
+                throw new ArgumentException($"page ({page}) must greater or equal than firstPage ({firstPage})");
+            if (size == 0)
+                throw new ArgumentException($"size ({size}) must greater than 0");
+            var total = await queryable.CountAsync();
+            var items = await queryable.Skip((page - firstPage) * size).Take(size).ToListAsync();
+            var totalPages = (int)Math.Ceiling(total / (double)size);
+            return new Paginate<T>
+            {
+                Page = page,
+                Size = size,
+                Total = total,
+                Items = items,
+                TotalPages = totalPages
+            };
+        }
+    }
+}

--- a/PMSAT.DataTier/Repository/Implement/GenericRepository.cs
+++ b/PMSAT.DataTier/Repository/Implement/GenericRepository.cs
@@ -1,0 +1,152 @@
+﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using LAK.Sdk.Core.Utilities;
+using PMSAT.DataTier.Paginate;
+using PMSAT.DataTier.Repository.Interfaces;
+
+namespace PMSAT.DataTier.Repository.Implement
+{
+    public class GenericRepository<T> : IGenericRepository<T> where T : class
+    {
+        protected readonly DbContext _dbContext;
+        protected readonly DbSet<T> _dbSet;
+
+        public GenericRepository(DbContext context)
+        {
+            _dbContext = context;
+            _dbSet = context.Set<T>();
+        }
+
+        public void Dispose()
+        {
+            _dbContext?.Dispose();
+        }
+
+        #region Get Async
+        public virtual async Task<T> SingleOrDefaultAsync(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            bool asNoTracking = true)
+        {
+            IQueryable<T> query = _dbSet;
+            if (include != null) query = include(query);
+            if (predicate != null) query = query.Where(predicate);
+            if (orderBy != null) query = orderBy(query);
+
+            return asNoTracking ? await query.AsNoTracking().FirstOrDefaultAsync() : await query.FirstOrDefaultAsync();
+        }
+
+        public virtual async Task<TResult> SingleOrDefaultAsync<TResult>(Expression<Func<T, TResult>> selector, Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null, bool asNoTracking = true)
+        {
+            IQueryable<T> query = _dbSet;
+
+            if (include != null) query = include(query);
+            if (predicate != null) query = query.Where(predicate);
+            if (orderBy != null) query = orderBy(query);
+
+            return asNoTracking ? await query.AsNoTracking().Select(selector).FirstOrDefaultAsync() : await query.Select(selector).FirstOrDefaultAsync();
+        }
+
+        public virtual async Task<ICollection<T>> GetListAsync(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null, bool asNoTracking = true, object filter = null, string sort = null, string order = null)
+        {
+            IQueryable<T> query = _dbSet;
+
+            if (include != null) query = include(query);
+            if (predicate != null) query = query.Where(predicate);
+
+            if (filter != null) query = query.DynamicFilter(filter);
+            if (orderBy != null) query = orderBy(query);
+            if (sort != null) query = query.DynamicSort(sort, order);
+
+            return asNoTracking ? await query.AsNoTracking().ToListAsync() : await query.ToListAsync();
+        }
+
+        public virtual async Task<ICollection<TResult>> GetListAsync<TResult>(Expression<Func<T, TResult>> selector, Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>,
+            IOrderedQueryable<T>> orderBy = null, Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null, bool asNoTracking = true, object filter = null,
+            string sort = null, string order = null)
+        {
+            IQueryable<T> query = _dbSet;
+
+            if (include != null) query = include(query);
+            if (predicate != null) query = query.Where(predicate);
+
+            if (filter != null) query = query.DynamicFilter(filter);
+            if (orderBy != null) query = orderBy(query);
+            if (sort != null) query = query.DynamicSort(sort, order);
+
+            return asNoTracking ? await query.AsNoTracking().Select(selector).ToListAsync() : await query.Select(selector).ToListAsync();
+        }
+
+        public Task<IPaginate<T>> GetPagingListAsync(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null, int page = 1,
+            int size = 10, object filter = null, string sort = null, string order = null)
+        {
+            IQueryable<T> query = _dbSet;
+
+            if (include != null) query = include(query);
+            if (predicate != null) query = query.Where(predicate);
+
+            if (filter != null) query = query.DynamicFilter(filter);
+            if (orderBy != null) query = orderBy(query);
+            if (sort != null) query = query.DynamicSort(sort, order);
+
+            return query.AsNoTracking().ToPaginateAsync(page, size, 1);
+        }
+
+        public Task<IPaginate<TResult>> GetPagingListAsync<TResult>(Expression<Func<T, TResult>> selector, Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null, int page = 1, int size = 10, object filter = null, string sort = null, string order = null)
+        {
+            IQueryable<T> query = _dbSet;
+
+            if (include != null) query = include(query);
+            if (predicate != null) query = query.Where(predicate);
+
+            if (filter != null) query = query.DynamicFilter(filter);
+            if (orderBy != null) query = orderBy(query);
+            if (sort != null) query = query.DynamicSort(sort, order);
+
+            return query.AsNoTracking().Select(selector).ToPaginateAsync(page, size, 1);
+        }
+
+        #endregion
+
+        #region Insert
+
+        public async Task InsertAsync(T entity)
+        {
+            if (entity == null) return;
+            await _dbSet.AddAsync(entity);
+        }
+
+        public async Task InsertRangeAsync(IEnumerable<T> entities)
+        {
+            await _dbSet.AddRangeAsync(entities);
+        }
+
+        #endregion
+
+        #region Update
+        public void UpdateAsync(T entity)
+        {
+            _dbSet.Update(entity);
+
+        }
+
+        public void UpdateRange(IEnumerable<T> entities)
+        {
+            _dbSet.UpdateRange(entities);
+        }
+
+        public void DeleteAsync(T entity)
+        {
+            _dbSet.Remove(entity);
+        }
+
+        public void DeleteRangeAsync(IEnumerable<T> entities)
+        {
+            _dbSet.RemoveRange(entities);
+        }
+
+        #endregion
+    }
+}

--- a/PMSAT.DataTier/Repository/Implement/UnitOfWork.cs
+++ b/PMSAT.DataTier/Repository/Implement/UnitOfWork.cs
@@ -1,0 +1,62 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using PMSAT.DataTier.Repository.Interfaces;
+using PMSAT.Repository.Interfaces;
+
+namespace PMSAT.DataTier.Repository.Implement
+{
+    public class UnitOfWork<TContext> : IUnitOfWork<TContext> where TContext : DbContext
+    {
+        public TContext Context { get; }
+        private Dictionary<Type, object> _repositories;
+
+        public UnitOfWork(TContext context)
+        {
+            Context = context;
+        }
+
+        public IGenericRepository<TEntity> GetRepository<TEntity>() where TEntity : class
+        {
+            _repositories ??= new Dictionary<Type, object>();
+            if (_repositories.TryGetValue(typeof(TEntity), out object repository))
+            {
+                return (IGenericRepository<TEntity>)repository;
+            }
+
+            repository = new GenericRepository<TEntity>(Context);
+            _repositories.Add(typeof(TEntity), repository);
+            return (IGenericRepository<TEntity>)repository;
+        }
+
+        public void Dispose()
+        {
+            Context?.Dispose();
+        }
+
+        public int Commit()
+        {
+            TrackChanges();
+            return Context.SaveChanges();
+        }
+
+        public async Task<int> CommitAsync()
+        {
+            TrackChanges();
+            return await Context.SaveChangesAsync();
+        }
+
+        private void TrackChanges()
+        {
+            var validationErrors = Context.ChangeTracker.Entries<IValidatableObject>()
+                .SelectMany(e => e.Entity.Validate(null))
+                .Where(e => e != ValidationResult.Success)
+                .ToArray();
+            if (validationErrors.Any())
+            {
+                var exceptionMessage = string.Join(Environment.NewLine,
+                    validationErrors.Select(error => $"Properties {error.MemberNames} Error: {error.ErrorMessage}"));
+                throw new Exception(exceptionMessage);
+            }
+        }
+    }
+}

--- a/PMSAT.DataTier/Repository/Interfaces/IGenericRepository.cs
+++ b/PMSAT.DataTier/Repository/Interfaces/IGenericRepository.cs
@@ -1,0 +1,76 @@
+﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using PMSAT.DataTier.Paginate;
+
+namespace PMSAT.DataTier.Repository.Interfaces
+{
+    public interface IGenericRepository<T> : IDisposable where T : class
+    {
+        #region Get Async
+        Task<T> SingleOrDefaultAsync(
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            bool asNoTracking = true);
+
+        Task<TResult> SingleOrDefaultAsync<TResult>(
+            Expression<Func<T, TResult>> selector,
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            bool asNoTracking = true);
+
+        Task<ICollection<T>> GetListAsync(
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            bool asNoTracking = true,
+            object filter = null, string? sort = null, string? order = null);
+
+        Task<ICollection<TResult>> GetListAsync<TResult>(
+            Expression<Func<T, TResult>> selector,
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            bool asNoTracking = true,
+            object filter = null, string? sort = null, string? order = null);
+
+        Task<IPaginate<T>> GetPagingListAsync(
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            int page = 1,
+            int size = 10,
+            object filter = null, string? sort = null, string? order = null);
+
+        Task<IPaginate<TResult>> GetPagingListAsync<TResult>(
+            Expression<Func<T, TResult>> selector,
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            int page = 1,
+            int size = 10,
+            object filter = null, string? sort = null, string? order = null);
+
+        #endregion
+
+        #region Insert
+
+        Task InsertAsync(T entity);
+
+        Task InsertRangeAsync(IEnumerable<T> entities);
+
+        #endregion
+
+        #region Update
+
+        void UpdateAsync(T entity);
+
+        void UpdateRange(IEnumerable<T> entities);
+
+        #endregion
+
+        void DeleteAsync(T entity);
+        void DeleteRangeAsync(IEnumerable<T> entities);
+    }
+}

--- a/PMSAT.DataTier/Repository/Interfaces/IGenericRepositoryFactory.cs
+++ b/PMSAT.DataTier/Repository/Interfaces/IGenericRepositoryFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace PMSAT.DataTier.Repository.Interfaces
+{
+    public interface IGenericRepositoryFactory
+    {
+        IGenericRepository<TEntity> GetRepository<TEntity>() where TEntity : class;
+    }
+}

--- a/PMSAT.DataTier/Repository/Interfaces/IUnitOfWork.cs
+++ b/PMSAT.DataTier/Repository/Interfaces/IUnitOfWork.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.EntityFrameworkCore;
+using PMSAT.DataTier.Repository.Interfaces;
+
+namespace PMSAT.Repository.Interfaces
+{
+    public interface IUnitOfWork : IGenericRepositoryFactory, IDisposable
+    {
+        int Commit();
+        Task<int> CommitAsync();
+    }
+
+    public interface IUnitOfWork<TContext> : IUnitOfWork where TContext : DbContext
+    {
+        TContext Context { get; }
+    }
+}

--- a/PMSAT.DataTier/note.txt
+++ b/PMSAT.DataTier/note.txt
@@ -1,0 +1,7 @@
+Scaffold-DbContext "Server=14.225.204.144,6789;Database=PMSAT;uid=pmsat;pwd=12345" Microsoft.EntityFrameworkCore.SqlServer -o Models -f
+
+dotnet tool install --global dotnet-ef
+dotnet tool install --global dotnet-ef --version 7.*
+
+dotnet ef dbcontext scaffold "Server=14.225.204.144,6789;Database=PMSAT;Uid=pmsat;Pwd=12345;TrustServerCertificate=True" Microsoft.EntityFrameworkCore.SqlServer -o Models -f
+

--- a/PMSAT.sln
+++ b/PMSAT.sln
@@ -1,0 +1,13 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35312.102
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0824F65C-3DAB-4FE8-92EA-35E3A2C11274}
+	EndGlobalSection
+EndGlobal

--- a/PMSAT.sln
+++ b/PMSAT.sln
@@ -3,7 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PMSAT.DataTier", "PMSAT.DataTier\PMSAT.DataTier.csproj", "{912F66D0-8AA8-473F-972A-B2834AC60224}"
+EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{912F66D0-8AA8-473F-972A-B2834AC60224}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{912F66D0-8AA8-473F-972A-B2834AC60224}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{912F66D0-8AA8-473F-972A-B2834AC60224}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{912F66D0-8AA8-473F-972A-B2834AC60224}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
This pull request introduces several new models and updates the `PmsatContext` class to include these models in the Entity Framework context. The most important changes include adding new classes for various entities, defining their properties, and configuring their relationships in the `PmsatContext` class.

### New Models

* [`PMSAT.DataTier/Models/BackLog.cs`](diffhunk://#diff-d98e0fe4bd393eee39bb7b998e303225e43fb54cfac3d93c2268ec7aab51a060R1-R17): Added a new `BackLog` class with properties such as `Id`, `ProjectId`, `Description`, and navigation properties to `Project` and `Tasks`.
* [`PMSAT.DataTier/Models/Commit.cs`](diffhunk://#diff-c03d86eca28998d05cf3f5d4cf8573d5e6cee6bf473c9a7c3873ca78ff349543R1-R17): Added a new `Commit` class with properties such as `Id`, `RepositoryId`, `Message`, `CreatedAt`, and a navigation property to `Repository`.
* [`PMSAT.DataTier/Models/Feedback.cs`](diffhunk://#diff-611a8f007336dd760c1a8a3e8585aa3bed761eb94c3c41e093eb5f6ebcb48f83R1-R17): Added a new `Feedback` class with properties such as `Id`, `UserId`, `Type`, `Content`, and a navigation property to `User`.
* [`PMSAT.DataTier/Models/IntegrationConfig.cs`](diffhunk://#diff-1ce4301db5a81f244df034d2e2a04277e0f8e1238c03a749033ba4daf9315fefR1-R21): Added a new `IntegrationConfig` class with properties such as `Id`, `UserId`, `ToolName`, `Settings`, `ApiKey`, `Url`, and a navigation property to `User`.
* Other models: Added classes for `Project`, `ProjectAnalysisResult`, `ProjectMember`, `ProjectRole`, `PullRequest`, `Repository`, `RoleInProject`, `Sprint`, `Task`, `TaskSprint`, and `User` with their respective properties and navigation properties. [[1]](diffhunk://#diff-5118f37af99f16ac2d30eb4c233d9fb84fae60b257c0e68f5ed87c8227864f78R1-R27) [[2]](diffhunk://#diff-c6fd9f14854288a31f31192e191729742cabb98e5d5ab5ed09057fdcf2be6b14R1-R25) [[3]](diffhunk://#diff-fc4addd4508edc5a7c7425f9164d0937f3d00f2ba7244fea12e0543c90fa53eeR1-R29) [[4]](diffhunk://#diff-844789d8c28cf471e08bf23538716dd01884848c7f59441e69d89b8152754264R1-R15) [[5]](diffhunk://#diff-43bed6054d85a136a8a4d750aae9714f1324310ed7e1a5b9a4e14bf12d208f81R1-R27) [[6]](diffhunk://#diff-606806617dbf42870dd0639f6735d9a21d0a524420d1a3d05d831c9303706f76R1-R21) [[7]](diffhunk://#diff-51e19c2c1c904d81df737c850d8370150fc879183d516e566298e951c2e9ab16R1-R17) [[8]](diffhunk://#diff-df8e0b90feae96dad416a73348ef22fe5a4bb82f6a2c104d808f912725d0d1c0R1-R23) [[9]](diffhunk://#diff-4a2634408050dcca04a35a9733ba4bc0245ace4cc6afaa87a03b29adbf80b896R1-R31) [[10]](diffhunk://#diff-3f4edb4d50b21a75157ebc107f5c69fcc95157e0e96e34dfb235f40d9dea41a2R1-R21) [[11]](diffhunk://#diff-79cb6abe83c6aa6ccd8382bf4e651f3696a5a2797ab9581ceda66d0273beae42R1-R25)

### Context Configuration

* [`PMSAT.DataTier/Models/PmsatContext.cs`](diffhunk://#diff-74d92447f7bfbdeac4270e135bfd4d00aa43cf91574f86c56e4e7d43a0fbbeebR1-R325): Updated the `PmsatContext` class to include `DbSet` properties for all the new models and configured their relationships using the `OnModelCreating` method. This includes defining table names, setting up foreign key constraints, and specifying property configurations such as data types and maximum lengths.